### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
     <title>Poetry by Abhishek</title>
     <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-26SJZ2E3TE"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-XXXXXXXXXX');
+      gtag('config', 'G-26SJZ2E3TE');
     </script>
   </head>
   <body class="bg-paper-light text-ink-light dark:bg-paper-dark dark:text-ink-dark min-h-screen">

--- a/index.html
+++ b/index.html
@@ -13,6 +13,14 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Rozha+One:wght@400;500;700&family=Noto+Serif+Devanagari:wght@400;500;700&family=Spectral:wght@400;500;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Lora:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
     <title>Poetry by Abhishek</title>
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXXXXX');
+    </script>
   </head>
   <body class="bg-paper-light text-ink-light dark:bg-paper-dark dark:text-ink-dark min-h-screen">
     <div id="root"></div>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-const GA_MEASUREMENT_ID = 'G-XXXXXXXXXX'
+const GA_MEASUREMENT_ID = 'G-26SJZ2E3TE'
 
 export const trackPoemView = (id: number) => {
   if (typeof window === 'undefined') return

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,8 +1,14 @@
+const GA_MEASUREMENT_ID = 'G-XXXXXXXXXX'
+
 export const trackPoemView = (id: number) => {
   if (typeof window === 'undefined') return
   const data = JSON.parse(localStorage.getItem('poemViews') || '{}') as Record<string, number>
   data[id] = (data[id] || 0) + 1
   localStorage.setItem('poemViews', JSON.stringify(data))
+  const w = window as unknown as { gtag?: (...args: unknown[]) => void }
+  if (w.gtag) {
+    w.gtag('event', 'poem_view', { poem_id: id })
+  }
 }
 
 export const getPoemViews = (id: number): number => {
@@ -16,4 +22,11 @@ export const trackPageView = (path: string) => {
   const pages = JSON.parse(localStorage.getItem('pageViews') || '{}') as Record<string, number>
   pages[path] = (pages[path] || 0) + 1
   localStorage.setItem('pageViews', JSON.stringify(pages))
+  const w = window as unknown as { gtag?: (...args: unknown[]) => void }
+  if (w.gtag) {
+    w.gtag('event', 'page_view', {
+      page_path: path,
+      send_to: GA_MEASUREMENT_ID
+    })
+  }
 }


### PR DESCRIPTION
## Summary
- load Google Analytics snippet in `index.html`
- send GA events from `trackPageView` and `trackPoemView`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850550623e483278ca2e52d5437db02