### PR TITLE
Enhance poem search with history and URL parameters

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -30,3 +30,22 @@ export const trackPageView = (path: string) => {
     })
   }
 }
+
+export const trackSearch = (query: string) => {
+  if (typeof window === 'undefined' || !query) return
+  const history = JSON.parse(localStorage.getItem('searchHistory') || '[]') as string[]
+  const existingIndex = history.indexOf(query)
+  if (existingIndex !== -1) history.splice(existingIndex, 1)
+  history.unshift(query)
+  if (history.length > 10) history.pop()
+  localStorage.setItem('searchHistory', JSON.stringify(history))
+  const w = window as unknown as { gtag?: (...args: unknown[]) => void }
+  if (w.gtag) {
+    w.gtag('event', 'search', { search_term: query })
+  }
+}
+
+export const getSearchHistory = (): string[] => {
+  if (typeof window === 'undefined') return []
+  return JSON.parse(localStorage.getItem('searchHistory') || '[]') as string[]
+}


### PR DESCRIPTION
## Summary
- track searches in local storage and GA
- persist search query and tag selections in URL
- show prior searches as suggestions
- add tag filter buttons instead of dropdown

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68506f3e3f7883278104c39b8355f580