### PR TITLE
Improve poem search UI

### DIFF
--- a/src/components/PoemPage.tsx
+++ b/src/components/PoemPage.tsx
@@ -14,6 +14,7 @@ import { useScriptPreference } from './ScriptPreference';
 import PoemComments from './PoemComments';
 import PoemLike from './PoemLike'; // Add this import
 import TranslationTooltip from './TranslationTooltip';
+import { Link } from 'react-router-dom';
 import allPoemTranslations, { romanToDevanagariMap } from '../translations/poemTranslations';
 
 interface PoemPageProps {
@@ -341,12 +342,13 @@ const PoemPage: FC<PoemPageProps> = ({ poem }) => {
           >
             <div className="flex flex-wrap gap-2">
               {poem.tags.map((tag) => (
-                <span
+                <Link
                   key={tag}
-                  className="px-3 py-1 text-xs rounded-full bg-sage-light/20 dark:bg-sage-dark/20 text-ink-light-secondary dark:text-ink-dark-secondary border border-sage-light/20 dark:border-sage-dark/20"
+                  to={`/?tag=${encodeURIComponent(tag)}`}
+                  className="px-3 py-1 text-xs rounded-full bg-sage-light/20 dark:bg-sage-dark/20 text-ink-light-secondary dark:text-ink-dark-secondary border border-sage-light/20 dark:border-sage-dark/20 hover:bg-accent-light/20 dark:hover:bg-accent-dark/20"
                 >
                   {tag}
-                </span>
+                </Link>
               ))}
             </div>
           </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -10,17 +10,12 @@
   body {
     @apply antialiased selection:bg-accent-light/20 dark:selection:bg-accent-dark/20;
     position: relative;
+    /* Subtle paper-like texture */
+    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.04'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
   }
 
-  body::before {
-    content: '';
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    background-image: radial-gradient(rgba(0,0,0,0.05) 1px, transparent 1px);
-    background-size: 3px 3px;
-    opacity: 0.4;
-    mix-blend-mode: multiply;
+  .dark body {
+    background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.02'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
   }
   
   .hindi {


### PR DESCRIPTION
## Summary
- remove tag filter list and search suggestions on poem index page
- keep tag filtering via URL and show active tag indicator

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68507d6a2bd0832794d26e0d45900924