### PR TITLE
Add simple subscription and notification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ export default tseslint.config({
   },
 })
 ```
+
+## Subscribing to New Poems
+
+To let readers receive updates when a new poem is added, a simple subscription system is included.
+
+1. Create a `subscribers` table in Supabase with at least an `email` column.
+2. Deploy the site with your Supabase credentials in `.env.local`.
+3. Visitors can sign up on the `/subscribe` page.
+4. After adding new poems to `src/data/poems.json`, run `node scripts/sendNewPoemEmails.js` to log email notifications (replace the logging with your email service to actually send messages).
+

--- a/scripts/sendNewPoemEmails.js
+++ b/scripts/sendNewPoemEmails.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { createClient } from '@supabase/supabase-js'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.local' })
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const supabaseUrl = process.env.VITE_SUPABASE_URL
+const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('Missing Supabase environment variables')
+  process.exit(1)
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey)
+const poemsPath = path.join(__dirname, '../src/data/poems.json')
+const poems = JSON.parse(fs.readFileSync(poemsPath, 'utf8'))
+
+const statePath = path.join(__dirname, 'last_poem_id.txt')
+let lastId = 0
+if (fs.existsSync(statePath)) {
+  lastId = parseInt(fs.readFileSync(statePath, 'utf8'), 10) || 0
+}
+
+const newPoems = poems.filter(p => p.id > lastId)
+
+async function main() {
+  if (newPoems.length === 0) {
+    console.log('No new poems found')
+    return
+  }
+
+  const { data: subscribers, error } = await supabase
+    .from('subscribers')
+    .select('email')
+
+  if (error) {
+    console.error('Failed to retrieve subscribers:', error)
+    return
+  }
+
+  for (const poem of newPoems) {
+    for (const sub of subscribers) {
+      console.log(`Notify ${sub.email} about new poem "${poem.title}"`)
+      // Integrate your email service here
+    }
+    if (poem.id > lastId) {
+      lastId = poem.id
+    }
+  }
+
+  fs.writeFileSync(statePath, String(lastId))
+}
+
+main()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import PoemIndex from './components/PoemIndex.tsx'
 import AuthorBio from './components/AuthorBio.tsx'
 import Contact from './components/Contact.tsx'
 import NotFound from './components/NotFound.tsx'
+import Subscribe from './components/Subscribe.tsx'
 import { trackPageView } from './lib/analytics'
 // import DebugEnv from './components/DebugEnv'
 
@@ -84,6 +85,7 @@ function App() {
             <Route path="/read" element={<PoemBook />} />
             <Route path="/about" element={<AuthorBio />} />
             <Route path="/contact" element={<Contact />} />
+            <Route path="/subscribe" element={<Subscribe />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </div>

--- a/src/components/LayoutHeader.tsx
+++ b/src/components/LayoutHeader.tsx
@@ -25,6 +25,7 @@ const LayoutHeader: FC<LayoutHeaderProps> = ({ darkMode, setDarkMode }) => {
     { path: '/read', label: 'Read', labelHindi: 'पढ़ें' },
     { path: '/about', label: 'About', labelHindi: 'परिचय' },
     { path: '/contact', label: 'Contact', labelHindi: 'संपर्क' },
+    { path: '/subscribe', label: 'Subscribe', labelHindi: 'सदस्यता' },
   ];
 
   return (

--- a/src/components/Subscribe.tsx
+++ b/src/components/Subscribe.tsx
@@ -1,0 +1,20 @@
+import { motion } from 'framer-motion'
+import SubscribeForm from './SubscribeForm'
+
+const Subscribe = () => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      className="max-w-xl mx-auto px-4 py-8"
+    >
+      <h1 className="text-3xl md:text-4xl font-bold text-center hindi text-accent-light dark:text-accent-dark mb-6">
+        सदस्यता लें
+      </h1>
+      <SubscribeForm />
+    </motion.div>
+  )
+}
+
+export default Subscribe

--- a/src/components/SubscribeForm.tsx
+++ b/src/components/SubscribeForm.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { addSubscriber } from '../lib/subscribers'
+
+const SubscribeForm = () => {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!email) return
+    setLoading(true)
+    const { error } = await addSubscriber(email)
+    if (error) {
+      setStatus('error')
+    } else {
+      setStatus('success')
+      setEmail('')
+    }
+    setTimeout(() => setStatus('idle'), 3000)
+    setLoading(false)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col items-start gap-3">
+      <input
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        required
+        placeholder="you@example.com"
+        className="w-full px-3 py-2 border border-ink-light/10 dark:border-ink-dark/10 rounded-lg bg-paper-accent dark:bg-paper-dark-accent focus:border-accent-light dark:focus:border-accent-dark outline-none"
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+          loading
+            ? 'bg-accent-light/50 dark:bg-accent-dark/50 text-paper-light dark:text-paper-dark cursor-not-allowed'
+            : 'bg-accent-light dark:bg-accent-dark text-paper-light dark:text-paper-dark hover:bg-accent-hover-light dark:hover:bg-accent-hover-dark'
+        }`}
+      >
+        {loading ? 'Subscribing...' : 'Subscribe'}
+      </button>
+      {status === 'success' && (
+        <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-states-success text-sm">
+          Thank you for subscribing!
+        </motion.p>
+      )}
+      {status === 'error' && (
+        <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-states-error text-sm">
+          Failed to subscribe. Please try again.
+        </motion.p>
+      )}
+    </form>
+  )
+}
+
+export default SubscribeForm

--- a/src/lib/subscribers.ts
+++ b/src/lib/subscribers.ts
@@ -1,0 +1,25 @@
+import { supabase } from './supabase'
+
+export interface Subscriber {
+  id: string
+  email: string
+  created_at: string
+}
+
+export const addSubscriber = async (email: string): Promise<{ error: string | null }> => {
+  const { error } = await supabase.from('subscribers').insert([{ email }])
+  if (error) {
+    console.error('Error adding subscriber:', error)
+    return { error: error.message }
+  }
+  return { error: null }
+}
+
+export const listSubscribers = async (): Promise<Subscriber[]> => {
+  const { data, error } = await supabase.from('subscribers').select('*')
+  if (error) {
+    console.error('Error fetching subscribers:', error)
+    return []
+  }
+  return data as Subscriber[]
+}


### PR DESCRIPTION
## Summary
- allow users to subscribe with email
- add `/subscribe` route and navigation item
- provide helper utilities to store subscribers via Supabase
- script to log notifications when new poems are added
- document the subscription workflow in README

## Testing
- `npx vitest run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508bc19f8c832788735641e0eaa198