### PR TITLE
Add email notification subscription

### DIFF
--- a/.github/workflows/notify-subscribers.yml
+++ b/.github/workflows/notify-subscribers.yml
@@ -1,0 +1,29 @@
+name: Notify Subscribers
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/data/poems.json'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: node scripts/notify-subscribers.mjs
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_SECURE: ${{ secrets.SMTP_SECURE }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Subscribe to new poems
+
+Visitors can subscribe with their email to receive a notification whenever a new poem is added. Email addresses are stored via Supabase and a GitHub Action sends updates when `src/data/poems.json` changes.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "framer-motion": "^12.10.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.5.3"
+    "react-router-dom": "^7.5.3",
+    "nodemailer": "^6.9.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/scripts/notify-subscribers.mjs
+++ b/scripts/notify-subscribers.mjs
@@ -1,0 +1,58 @@
+import { execSync } from 'child_process'
+import fs from 'fs'
+import nodemailer from 'nodemailer'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing Supabase configuration')
+  process.exit(1)
+}
+
+const previousJson = execSync('git show HEAD^:src/data/poems.json', { encoding: 'utf8' })
+const previousPoems = JSON.parse(previousJson)
+const currentPoems = JSON.parse(fs.readFileSync('src/data/poems.json', 'utf8'))
+
+const previousIds = new Set(previousPoems.map(p => p.id))
+const newPoems = currentPoems.filter(p => !previousIds.has(p.id))
+
+if (newPoems.length === 0) {
+  console.log('No new poems added, exiting.')
+  process.exit(0)
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey)
+const { data: subscribers, error } = await supabase.from('subscriptions').select('email')
+
+if (error) {
+  console.error('Error fetching subscribers', error)
+  process.exit(1)
+}
+
+if (!subscribers || subscribers.length === 0) {
+  console.log('No subscribers to notify.')
+  process.exit(0)
+}
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT || '587', 10),
+  secure: process.env.SMTP_SECURE === 'true',
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+})
+
+for (const poem of newPoems) {
+  const text = poem.lines.join('\n')
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM,
+    bcc: subscribers.map(s => s.email).join(','),
+    subject: `New poem published: ${poem.title}`,
+    text,
+  })
+  console.log(`Notified subscribers about poem ${poem.title}`)
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import PoemBook from './components/PoemBook.tsx'
 import PoemIndex from './components/PoemIndex.tsx'
 import AuthorBio from './components/AuthorBio.tsx'
 import Contact from './components/Contact.tsx'
+import Subscribe from './components/Subscribe.tsx'
 import NotFound from './components/NotFound.tsx'
 // import DebugEnv from './components/DebugEnv'
 
@@ -77,6 +78,7 @@ function App() {
             <Route path="/read" element={<PoemBook />} />
             <Route path="/about" element={<AuthorBio />} />
             <Route path="/contact" element={<Contact />} />
+            <Route path="/subscribe" element={<Subscribe />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </div>

--- a/src/components/LayoutHeader.tsx
+++ b/src/components/LayoutHeader.tsx
@@ -25,6 +25,7 @@ const LayoutHeader: FC<LayoutHeaderProps> = ({ darkMode, setDarkMode }) => {
     { path: '/', label: 'Index', labelHindi: 'सूची' },
     { path: '/about', label: 'About', labelHindi: 'परिचय' },
     { path: '/contact', label: 'Contact', labelHindi: 'संपर्क' },
+    { path: '/subscribe', label: 'Subscribe', labelHindi: 'सदस्यता' },
   ];
 
   return (

--- a/src/components/Subscribe.tsx
+++ b/src/components/Subscribe.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { supabase } from '../lib/supabase'
+
+const Subscribe = () => {
+  const [email, setEmail] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!email.trim()) return
+    setIsSubmitting(true)
+    try {
+      const { error } = await supabase
+        .from('subscriptions')
+        .insert([{ email: email.trim() }])
+      if (error) throw error
+      setStatus('success')
+      setEmail('')
+    } catch (err) {
+      console.error('Error subscribing:', err)
+      setStatus('error')
+    } finally {
+      setIsSubmitting(false)
+      setTimeout(() => setStatus('idle'), 3000)
+    }
+  }
+
+  const fadeInUp = {
+    hidden: { opacity: 0, y: 20 },
+    visible: { opacity: 1, y: 0 }
+  }
+
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={fadeInUp}
+      transition={{ duration: 0.6 }}
+      className="max-w-4xl mx-auto px-4 py-8"
+    >
+      <div className="bg-paper-light dark:bg-paper-dark rounded-xl p-8 md:p-12 shadow-medium border border-ink-light/10 dark:border-ink-dark/10">
+        <motion.h1
+          variants={fadeInUp}
+          className="text-3xl md:text-4xl font-bold hindi text-accent-light dark:text-accent-dark mb-6 text-center"
+        >
+          Subscribe for Updates
+        </motion.h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="you@example.com"
+            className="w-full px-3 py-2 border border-ink-light/10 dark:border-ink-dark/10 rounded-lg bg-paper-accent dark:bg-paper-dark-accent focus:border-accent-light dark:focus:border-accent-dark outline-none transition-colors"
+          />
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className={`w-full py-2 px-4 rounded-lg font-medium transition-colors ${
+              isSubmitting
+                ? 'bg-accent-light/50 dark:bg-accent-dark/50 text-paper-light dark:text-paper-dark cursor-not-allowed'
+                : 'bg-accent-light dark:bg-accent-dark hover:bg-accent-hover-light dark:hover:bg-accent-hover-dark text-paper-light dark:text-paper-dark'
+            }`}
+          >
+            {isSubmitting ? 'Subscribing...' : 'Subscribe'}
+          </button>
+        </form>
+        {status === 'success' && (
+          <motion.p
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-states-success text-sm text-center"
+          >
+            Thank you! You will be notified when new poems are published.
+          </motion.p>
+        )}
+        {status === 'error' && (
+          <motion.p
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-states-error text-sm text-center"
+          >
+            Sorry, there was an error. Please try again later.
+          </motion.p>
+        )}
+      </div>
+    </motion.div>
+  )
+}
+
+export default Subscribe

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,3 +11,9 @@ export interface Poem {
   romanizedLines?: string[];
   translations?: Record<string, string>;
 }
+
+export interface Subscriber {
+  id: string
+  email: string
+  created_at: string
+}


### PR DESCRIPTION
## Summary
- add subscribe page with email form
- include route and nav link
- document subscription in README
- notify subscribers via GitHub Action and Node script
- add nodemailer dependency

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68504dd5c6f08327ac249e8ab146d5be