### PR TITLE
Add database and SMTP setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,87 @@ export default tseslint.config({
 
 To let readers receive updates when a new poem is added, a simple subscription system is included.
 
-1. Create a `subscribers` table in Supabase with at least an `email` column.
+1. Create the `subscribers` table in Supabase using the SQL below.
+
+   ```sql
+   create table if not exists subscribers (
+     id uuid primary key default uuid_generate_v4(),
+     email text unique not null,
+     created_at timestamp with time zone default now()
+   );
+   ```
+
+   Enable row level security so anyone can read but only your application can insert.
 2. Deploy the site with your Supabase credentials in `.env.local`.
 3. Visitors can sign up on the `/subscribe` page.
 4. After adding new poems to `src/data/poems.json`, run `node scripts/sendNewPoemEmails.js` to log email notifications (replace the logging with your email service to actually send messages).
 
+
+## Database Setup for Comments and Likes
+
+To enable reflections and likes in the application create the following tables in Supabase. The easiest way is through the SQL editor in the Supabase dashboard.
+
+### `comments` table
+```sql
+create table if not exists comments (
+  id uuid primary key default uuid_generate_v4(),
+  poem_id integer not null,
+  author text not null,
+  content text not null,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+```
+
+### `likes` table
+```sql
+create table if not exists likes (
+  id uuid primary key default uuid_generate_v4(),
+  comment_id uuid references comments(id) on delete cascade,
+  session_id uuid not null,
+  created_at timestamp with time zone default now()
+);
+```
+
+### `poem_likes` table
+```sql
+create table if not exists poem_likes (
+  id uuid primary key default uuid_generate_v4(),
+  poem_id integer not null,
+  session_id uuid not null,
+  created_at timestamp with time zone default now(),
+  unique(poem_id, session_id)
+);
+```
+
+### Aggregated views
+Create helper views so the UI can query like counts efficiently.
+```sql
+create or replace view poem_like_counts as
+select poem_id, count(*) as likes_count
+from poem_likes
+group by poem_id;
+
+create or replace view comments_with_likes as
+select c.*, count(l.id) as likes_count
+from comments c
+left join likes l on l.comment_id = c.id
+group by c.id;
+```
+
+Enable row level security on these tables and create policies so anyone can read them but only the application can insert records.
+
+## Sending Email Notifications via GitHub and SMTP
+
+The script `scripts/sendNewPoemEmails.js` is used to notify subscribers when new poems are committed. To actually deliver messages you need to provide SMTP credentials and run the script in CI.
+
+1. Add an SMTP library such as `nodemailer` to the project:
+   ```bash
+   npm install nodemailer
+   ```
+   Update `scripts/sendNewPoemEmails.js` to send emails using these credentials.
+2. Store your SMTP settings in GitHub repository secrets (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`).
+3. Create a workflow in `.github/workflows/notify.yml` that installs dependencies and runs the notification script. Make sure to pass the SMTP secrets as environment variables.
+4. **Using Gmail:** set `SMTP_HOST=smtp.gmail.com`, `SMTP_PORT=465` (or `587` for TLS), `SMTP_USER` to your Gmail address, and `SMTP_PASS` to a Gmail App Password.
+
+With this setup each push that adds new poems can trigger the workflow and emails will be sent via your SMTP server.


### PR DESCRIPTION
## Summary
- document SQL snippet for creating the `subscribers` table
- add instructions for using Gmail as the SMTP provider

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68509b9167d483278dc1cb1e7d318b56