### PR TITLE
Adjust poem page line spacing

### DIFF
--- a/src/components/PoemPage.tsx
+++ b/src/components/PoemPage.tsx
@@ -324,7 +324,7 @@ const PoemPage: FC<PoemPageProps> = ({ poem }) => {
               variants={lineVariants}
               initial="hidden"
               animate="visible"
-              className={`${textSizeClass} leading-relaxed md:leading-loose text-ink-light dark:text-ink-dark indent-4 ${
+              className={`${textSizeClass} text-ink-light dark:text-ink-dark indent-4 ${
                 script === 'devanagari' ? 'hindi' : 'roman'
               }`}
             >

--- a/src/index.css
+++ b/src/index.css
@@ -28,22 +28,20 @@
     font-family: 'merriweather', sans-serif;
     font-size: 20px;
     text-rendering: optimizeLegibility;
-    line-height: 2 !important;
-    @apply leading-relaxed;
+    @apply leading-normal md:leading-relaxed;
   }
 
   .roman {
     font-family: 'merriweather', sans-serif;
     font-size: 20px;
     text-rendering: optimizeLegibility;
-    line-height: 2 !important;
-    @apply leading-relaxed;
+    @apply leading-normal md:leading-relaxed;
   }
 
   .hindi, .roman {
     @apply font-serif; /* Use the new serif font (Lora) */
     font-size: 1.2rem; /* A slightly more readable base size */
-    @apply leading-loose md:leading-loose; /* Increase line spacing */
+    @apply leading-normal md:leading-relaxed;
     text-rendering: optimizeLegibility;
   }
     


### PR DESCRIPTION
## Summary
- tighten default typography line-height
- remove explicit leading props from poem lines

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850fc2b93c083278f51a899eb7a8d79